### PR TITLE
Fix automation-agent Docker build when artifacts folder is absent.

### DIFF
--- a/automation-agent/Dockerfile
+++ b/automation-agent/Dockerfile
@@ -6,7 +6,7 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 COPY src ./src
-COPY artifacts ./artifacts
+RUN mkdir -p ./artifacts/screenshots ./artifacts/videos ./artifacts/traces ./artifacts/stagehand-cache
 
 ENV PORT=7400
 EXPOSE 7400


### PR DESCRIPTION
Replace copying local artifacts with creating runtime artifact directories so CI image builds consistently.

Made-with: Cursor