### PR TITLE
Update deployment workflow to stop all Docker containers before setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,8 +96,9 @@ jobs:
           set -e
           SSH="ssh -o StrictHostKeyChecking=no root@$DROPLET_IP"
 
-          # Stop old container if it was binding port 80 directly
-          $SSH "cd /opt/bettercases/frontend 2>/dev/null && docker compose down 2>/dev/null || true"
+          # Stop all containers on this droplet to free ports
+          $SSH "docker stop \$(docker ps -q) 2>/dev/null || true"
+          $SSH "docker rm \$(docker ps -aq) 2>/dev/null || true"
 
           # Set up Nginx + SSL (idempotent)
           scp -o StrictHostKeyChecking=no deploy/nginx/setup-ssl.sh root@"$DROPLET_IP":/tmp/setup-ssl.sh
@@ -139,8 +140,9 @@ jobs:
           set -e
           SSH="ssh -o StrictHostKeyChecking=no root@$DROPLET_IP"
 
-          # Stop old container if it was binding port 80 directly
-          $SSH "cd /opt/bettercases/backend 2>/dev/null && docker compose down 2>/dev/null || true"
+          # Stop all containers on this droplet to free ports
+          $SSH "docker stop \$(docker ps -q) 2>/dev/null || true"
+          $SSH "docker rm \$(docker ps -aq) 2>/dev/null || true"
 
           # Set up Nginx + SSL (idempotent)
           scp -o StrictHostKeyChecking=no deploy/nginx/setup-ssl.sh root@"$DROPLET_IP":/tmp/setup-ssl.sh
@@ -208,8 +210,9 @@ jobs:
           set -e
           SSH="ssh -o StrictHostKeyChecking=no root@$DROPLET_IP"
 
-          # Stop old container if it was binding port 80 directly
-          $SSH "cd /opt/bettercases/automation-agent 2>/dev/null && docker compose down 2>/dev/null || true"
+          # Stop all containers on this droplet to free ports
+          $SSH "docker stop \$(docker ps -q) 2>/dev/null || true"
+          $SSH "docker rm \$(docker ps -aq) 2>/dev/null || true"
 
           # Set up Nginx + SSL (idempotent)
           scp -o StrictHostKeyChecking=no deploy/nginx/setup-ssl.sh root@"$DROPLET_IP":/tmp/setup-ssl.sh


### PR DESCRIPTION
- Modified the deployment script to stop and remove all running Docker containers on the droplet, ensuring that ports are freed up for new deployments.
- This change enhances the deployment process by preventing port conflicts and improving the reliability of the setup for Nginx and SSL configuration.