### PR TITLE
Fix execution service auth header to use x-agent-token

### DIFF
--- a/Tesbo-Backend/src/main/java/com/bettercases/testexecution/ExternalExecutionServiceClient.java
+++ b/Tesbo-Backend/src/main/java/com/bettercases/testexecution/ExternalExecutionServiceClient.java
@@ -224,7 +224,7 @@ public final class ExternalExecutionServiceClient {
     private static void addAuth(HttpRequest.Builder builder) {
         String apiKey = Config.EXECUTION_SERVICE_API_KEY;
         if (apiKey != null && !apiKey.isBlank()) {
-            builder.header("x-api-key", apiKey);
+            builder.header("x-agent-token", apiKey);
         }
     }
 


### PR DESCRIPTION
Backend was sending x-api-key but internalAuth middleware on the execution service reads x-agent-token / x-automation-token, causing all /api/apikeys requests to be rejected.