### PR TITLE
Add API endpoint to resolve project by ingestion key

### DIFF
--- a/Tesbo-Backend/src/main/java/com/bettercases/Main.java
+++ b/Tesbo-Backend/src/main/java/com/bettercases/Main.java
@@ -257,6 +257,7 @@ public final class Main {
         app.post("/api/tesbo-reports/ingest/playwright", TesboReportsHandler::ingestPlaywrightByKey);
         app.post("/api/tesbo-reports/ingest/playwright/upload", TesboReportsHandler::ingestPlaywrightFileByKey);
         app.post("/api/tesbo-reports/runs/{runId}/cases/{caseId}/artifacts/{kind}/upload", TesboReportsHandler::uploadCaseArtifactByKey);
+        app.get("/api/tesbo-reports/project-by-key", TesboReportsHandler::resolveProjectByKey);
         app.get("/api/public/tesbo-reports/{token}", TesboReportsHandler::getPublicSharedRun);
         app.get("/api/public/tesbo-reports/{token}/cases/{caseId}/artifacts/{kind}", TesboReportsHandler::getPublicSharedArtifact);
 

--- a/Tesbo-Backend/src/main/java/com/bettercases/ai/AiKeySanitizer.java
+++ b/Tesbo-Backend/src/main/java/com/bettercases/ai/AiKeySanitizer.java
@@ -12,9 +12,17 @@ public final class AiKeySanitizer {
             key = key.substring(1, key.length() - 1).trim();
         }
 
-        if (key.regionMatches(true, 0, "Bearer ", 0, 7)) {
-            key = key.substring(7).trim();
+        if (key.toLowerCase().startsWith("bearer")) {
+            int split = key.indexOf(' ');
+            if (split < 0) {
+                key = "";
+            } else {
+                key = key.substring(split + 1).trim();
+            }
         }
+
+        // Provider keys should not contain whitespace; strip hidden newlines/tabs from copy-paste.
+        key = key.replaceAll("\\s+", "");
 
         return key;
     }

--- a/Tesbo-Backend/src/main/java/com/bettercases/tesbo/TesboReportsHandler.java
+++ b/Tesbo-Backend/src/main/java/com/bettercases/tesbo/TesboReportsHandler.java
@@ -272,6 +272,14 @@ public final class TesboReportsHandler {
         }
     }
 
+    public static void resolveProjectByKey(Context ctx) {
+        String ingestionKey = extractIngestionKey(ctx);
+        if (ingestionKey == null || ingestionKey.isBlank()) {
+            throw new io.javalin.http.UnauthorizedResponse("Project access key is required");
+        }
+        ctx.json(TesboReportsService.resolveProjectByIngestionKey(ingestionKey));
+    }
+
     public static void uploadCaseArtifact(Context ctx) {
         UUID projectId = UUID.fromString(ctx.pathParam("projectId"));
         UUID runId = UUID.fromString(ctx.pathParam("runId"));

--- a/Tesbo-Backend/src/main/java/com/bettercases/tesbo/TesboReportsService.java
+++ b/Tesbo-Backend/src/main/java/com/bettercases/tesbo/TesboReportsService.java
@@ -943,6 +943,11 @@ public final class TesboReportsService {
         }
     }
 
+    public static Map<String, Object> resolveProjectByIngestionKey(String ingestionKey) {
+        UUID projectId = resolveProjectIdByIngestionKey(ingestionKey);
+        return Map.of("projectId", projectId.toString());
+    }
+
     private static Map<String, Object> mapRunRow(ResultSet rs) throws SQLException {
         Map<String, Object> row = new LinkedHashMap<>();
         row.put("id", rs.getObject("id").toString());


### PR DESCRIPTION
- Introduced a new GET endpoint `/api/tesbo-reports/project-by-key` in Main.java to allow clients to retrieve project information using an ingestion key.
- Implemented the `resolveProjectByKey` method in TesboReportsHandler to handle the request and validate the ingestion key.
- Added the `resolveProjectByIngestionKey` method in TesboReportsService to fetch project details based on the provided key.

These changes enhance the API's functionality by enabling project resolution through ingestion keys, improving user access to project data.