### PR TITLE
Enhance artifact URL handling in report runs

### DIFF
--- a/Tesbo-Frontend/app/(app)/projects/[id]/tesbo-reports/runs/[runId]/page.tsx
+++ b/Tesbo-Frontend/app/(app)/projects/[id]/tesbo-reports/runs/[runId]/page.tsx
@@ -580,6 +580,23 @@ function Stat({ label, value, tone }: { label: string; value: string | number; t
 
 function toAbsoluteArtifactUrl(url: string): string {
   if (!url) return url;
-  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    try {
+      const parsed = new URL(url);
+      // Some deployments store absolute artifact URLs on a backend-only host.
+      // When the same path is exposed via the current app host, prefer it so
+      // browser viewers (including Playwright trace viewer) can load artifacts.
+      if (typeof window !== "undefined") {
+        const backendOnlyHost = parsed.hostname.toLowerCase().includes("backdoor");
+        const likelyPublicArtifactPath = parsed.pathname.startsWith("/app/artifacts/");
+        if ((backendOnlyHost || likelyPublicArtifactPath) && parsed.origin !== window.location.origin) {
+          return `${window.location.origin}${parsed.pathname}${parsed.search}`;
+        }
+      }
+      return parsed.toString();
+    } catch {
+      return url;
+    }
+  }
   return `${API_BASE}${url.startsWith("/") ? "" : "/"}${url}`;
 }


### PR DESCRIPTION
- Updated the `toAbsoluteArtifactUrl` function to improve URL resolution for artifacts, ensuring that paths exposed via the current app host are preferred over backend-only hosts.
- Added error handling for invalid URLs and refined logic to return appropriate artifact URLs based on the deployment context.

These changes enhance the accessibility of artifacts in the application, improving user experience when viewing reports.