### PR TITLE
Enhance TesboReportsService and frontend report runs display

### DIFF
--- a/Tesbo-Backend/src/main/java/com/bettercases/tesbo/TesboReportsService.java
+++ b/Tesbo-Backend/src/main/java/com/bettercases/tesbo/TesboReportsService.java
@@ -710,6 +710,11 @@ public final class TesboReportsService {
 
         try (Connection c = Database.getDataSource().getConnection()) {
             c.setAutoCommit(false);
+
+            if (runNumber == null || runNumber.isBlank()) {
+                runNumber = nextRunNumber(c, projectId);
+            }
+
             UUID runId;
             try (PreparedStatement ps = c.prepareStatement(insertRunSql)) {
                 ps.setObject(1, projectId);
@@ -738,6 +743,21 @@ public final class TesboReportsService {
                  project_name, browser_name, browser_version, os_name, os_platform, os_arch,
                  tags_json, steps_json, executed_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?::jsonb, ?)
+                ON CONFLICT (run_id, spec_name, test_name) DO UPDATE SET
+                  status = EXCLUDED.status,
+                  duration_ms = EXCLUDED.duration_ms,
+                  trace_url = COALESCE(EXCLUDED.trace_url, tesbo_report_cases.trace_url),
+                  screenshot_url = COALESCE(EXCLUDED.screenshot_url, tesbo_report_cases.screenshot_url),
+                  video_url = COALESCE(EXCLUDED.video_url, tesbo_report_cases.video_url),
+                  trace_storage_key = COALESCE(EXCLUDED.trace_storage_key, tesbo_report_cases.trace_storage_key),
+                  screenshot_storage_key = COALESCE(EXCLUDED.screenshot_storage_key, tesbo_report_cases.screenshot_storage_key),
+                  video_storage_key = COALESCE(EXCLUDED.video_storage_key, tesbo_report_cases.video_storage_key),
+                  full_title = COALESCE(EXCLUDED.full_title, tesbo_report_cases.full_title),
+                  error_message = EXCLUDED.error_message,
+                  error_stack = EXCLUDED.error_stack,
+                  attempt = EXCLUDED.attempt,
+                  steps_json = EXCLUDED.steps_json,
+                  executed_at = COALESCE(EXCLUDED.executed_at, tesbo_report_cases.executed_at)
                 """;
             try (PreparedStatement ps = c.prepareStatement(insertCaseSql)) {
                 for (Map<String, Object> test : tests) {
@@ -1227,6 +1247,16 @@ public final class TesboReportsService {
             if (item instanceof Map<?, ?>) out.add((Map<String, Object>) item);
         }
         return out;
+    }
+
+    private static String nextRunNumber(Connection c, UUID projectId) throws SQLException {
+        String sql = "SELECT COUNT(*)::int + 1 AS next_num FROM tesbo_report_runs WHERE project_id = ?";
+        try (PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setObject(1, projectId);
+            ResultSet rs = ps.executeQuery();
+            rs.next();
+            return String.valueOf(rs.getInt("next_num"));
+        }
     }
 
     private static String asText(Object value, String fallback) {

--- a/Tesbo-Backend/src/main/resources/db/changelog/changes/V33_tesbo_report_cases_unique.sql
+++ b/Tesbo-Backend/src/main/resources/db/changelog/changes/V33_tesbo_report_cases_unique.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+--changeset bettercases:V33-tesbo-report-cases-unique
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tesbo_cases_run_spec_test
+    ON tesbo_report_cases (run_id, spec_name, test_name);

--- a/Tesbo-Backend/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/Tesbo-Backend/src/main/resources/db/changelog/db.changelog-master.xml
@@ -36,4 +36,5 @@
     <include file="changes/V30_automation_jobs_dispatch_index.sql" relativeToChangelogFile="true"/>
     <include file="changes/V31_platform_admins.sql" relativeToChangelogFile="true"/>
     <include file="changes/V32_project_type.sql" relativeToChangelogFile="true"/>
+    <include file="changes/V33_tesbo_report_cases_unique.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/Tesbo-Frontend/app/(app)/projects/[id]/tesbo-reports/runs/page.tsx
+++ b/Tesbo-Frontend/app/(app)/projects/[id]/tesbo-reports/runs/page.tsx
@@ -227,7 +227,7 @@ export default function TesboRunsPage() {
                 <tbody>
                   {paginatedRuns.map((run, idx) => (
                     <tr key={run.id} className="cursor-pointer" onClick={() => router.push(`/projects/${projectId}/tesbo-reports/runs/${run.id}`)}>
-                      <td className="px-4 py-3 font-semibold text-[var(--foreground)]">#{run.runNumber || String((runPage - 1) * pageSize + idx + 1)}</td>
+                      <td className="px-4 py-3 font-semibold text-[var(--foreground)]">#{run.runNumber || String(runs.length - ((runPage - 1) * pageSize + idx))}</td>
                       <td className="px-4 py-3">{run.name}</td>
                       <td className="px-4 py-3">{run.branchName || "-"}</td>
                       <td className="px-4 py-3">{run.pullRequest || "-"}</td>


### PR DESCRIPTION
- Added logic to automatically generate the run number if not provided in the TesboReportsService.
- Updated SQL insert statement to handle conflicts by updating existing records with new data for report cases.
- Introduced a new method to calculate the next run number based on existing records.
- Modified the frontend to correctly display the run number based on the current pagination state, improving user experience in the reports section.