### PR TITLE
Refactor unique index creation for tesbo_report_cases

### DIFF
--- a/Tesbo-Backend/src/main/resources/db/changelog/changes/V33_tesbo_report_cases_unique.sql
+++ b/Tesbo-Backend/src/main/resources/db/changelog/changes/V33_tesbo_report_cases_unique.sql
@@ -1,5 +1,15 @@
 --liquibase formatted sql
---changeset bettercases:V33-tesbo-report-cases-unique
+--changeset bettercases:V33-tesbo-report-cases-unique-v2
 
-CREATE UNIQUE INDEX IF NOT EXISTS uq_tesbo_cases_run_spec_test
+DELETE FROM tesbo_report_cases
+WHERE id NOT IN (
+    SELECT DISTINCT ON (run_id, spec_name, test_name) id
+    FROM tesbo_report_cases
+    ORDER BY run_id, spec_name, test_name,
+             CASE status WHEN 'Failed' THEN 1 WHEN 'Passed' THEN 2 ELSE 3 END,
+             executed_at DESC NULLS LAST,
+             created_at DESC NULLS LAST
+);
+
+CREATE UNIQUE INDEX uq_tesbo_cases_run_spec_test
     ON tesbo_report_cases (run_id, spec_name, test_name);


### PR DESCRIPTION
- Updated the changeset to delete non-distinct records from tesbo_report_cases before creating a unique index on run_id, spec_name, and test_name.
- This change ensures that only the most relevant records are retained, improving data integrity and query performance.