### PR TITLE
Gate Stripe billing and plan limits behind STRIPE_SECRET_KEY.

### DIFF
--- a/Tesbo-Backend-Nest/src/billing/billing.service.ts
+++ b/Tesbo-Backend-Nest/src/billing/billing.service.ts
@@ -23,6 +23,8 @@ export type Currency = "usd" | "inr";
 export type BillingRequestContext = Pick<Request, "ip" | "headers">;
 
 export interface BillingInfo {
+  /** False when STRIPE_SECRET_KEY is unset — Stripe checkout/portal are unavailable. */
+  enabled: boolean;
   plan: "launch" | "pro";
   billingInterval: BillingInterval | null;
   status: string | null;
@@ -114,6 +116,14 @@ export class BillingService {
     }
   }
 
+  private requireStripeEnabled(): void {
+    if (!this.config.isStripeBillingEnabled) {
+      throw new ServiceUnavailableException({
+        error: "Stripe billing is not configured. Set STRIPE_SECRET_KEY (and price IDs) in .env to enable it."
+      });
+    }
+  }
+
   // Stripe SDK errors are plain Error subclasses, not NestJS HttpExceptions, so left
   // uncaught they all surface to the client as a generic "Internal server error" —
   // this turns them into a clear, appropriately-coded response instead.
@@ -134,6 +144,21 @@ export class BillingService {
   async getBillingInfo(userId: string | null | undefined): Promise<BillingInfo> {
     const uid = this.requireUser(userId);
     const workspace = await this.legacy.workspace(uid);
+    // Stripe not configured: keep the settings page loadable, unlock Pro-gated UI, no Stripe calls.
+    if (!this.config.isStripeBillingEnabled) {
+      return {
+        enabled: false,
+        plan: "pro",
+        billingInterval: null,
+        status: null,
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        paymentFailedAt: null,
+        graceEndsAt: null,
+        inGracePeriod: false,
+        limitsEnforced: false
+      };
+    }
     await this.reconcileDriftedPlan(workspace.id, uid);
     const res = await this.db.query(
       `SELECT plan, billing_interval, subscription_status, current_period_end, cancel_at_period_end,
@@ -146,6 +171,7 @@ export class BillingService {
     const graceEndsAt: string | null = row?.plan_grace_ends_at ?? null;
     const inGracePeriod = plan === "launch" && !!graceEndsAt && new Date(graceEndsAt).getTime() > Date.now();
     return {
+      enabled: true,
       plan,
       billingInterval: row?.billing_interval ?? null,
       status: row?.subscription_status ?? null,
@@ -266,6 +292,7 @@ export class BillingService {
     req: BillingRequestContext | undefined,
     requestedCurrency?: string
   ): Promise<BillingPricing> {
+    this.requireStripeEnabled();
     const lockedCurrency = await this.lockedCurrencyFor(userId);
     const eligibility = await this.resolveIndiaEligibility(userId, req, lockedCurrency);
     const currency = await this.resolveCurrency(req, requestedCurrency, lockedCurrency, eligibility.indiaEligible);
@@ -336,6 +363,7 @@ export class BillingService {
     req: BillingRequestContext | undefined,
     requestedCurrency?: string
   ): Promise<{ url: string }> {
+    this.requireStripeEnabled();
     const uid = this.requireUser(userId);
     const workspace = await this.legacy.workspace(uid);
     this.requireOwner(workspace.role);
@@ -370,6 +398,7 @@ export class BillingService {
   }
 
   async createPortalSession(userId: string | null | undefined): Promise<{ url: string }> {
+    this.requireStripeEnabled();
     const uid = this.requireUser(userId);
     const workspace = await this.legacy.workspace(uid);
     this.requireOwner(workspace.role);
@@ -391,6 +420,7 @@ export class BillingService {
   }
 
   async constructWebhookEvent(rawBody: Buffer | undefined, signature: string | undefined): Promise<Stripe.Event> {
+    this.requireStripeEnabled();
     if (!rawBody || !signature) throw new BadRequestException({ error: "Missing Stripe signature" });
     if (!this.config.stripeWebhookSecret) throw new BadRequestException({ error: "Stripe webhook secret is not configured" });
     try {
@@ -554,6 +584,7 @@ export class BillingService {
    * successfully would sit on the free plan until someone noticed.
    */
   async reconcileFromStripe(userId: string | null | undefined): Promise<BillingInfo> {
+    this.requireStripeEnabled();
     const uid = this.requireUser(userId);
     const workspace = await this.legacy.workspace(uid);
     const res = await this.db.query<{ stripe_customer_id: string | null }>(
@@ -663,6 +694,7 @@ export class BillingService {
    * URLs it returns are what customers actually need for accounting.
    */
   async getInvoices(userId: string | null | undefined): Promise<BillingInvoice[]> {
+    this.requireStripeEnabled();
     const uid = this.requireUser(userId);
     const workspace = await this.legacy.workspace(uid);
     const res = await this.db.query<{ stripe_customer_id: string | null }>(

--- a/Tesbo-Backend-Nest/src/config/app-config.service.ts
+++ b/Tesbo-Backend-Nest/src/config/app-config.service.ts
@@ -84,6 +84,12 @@ export class AppConfigService {
   // above, charged instead when the buyer is detected as being in India.
   readonly stripePriceIdProMonthlyInr = this.optionalString("STRIPE_PRICE_ID_PRO_MONTHLY_INR");
   readonly stripePriceIdProAnnualInr = this.optionalString("STRIPE_PRICE_ID_PRO_ANNUAL_INR");
+  /**
+   * Billing/Stripe is optional. Empty STRIPE_SECRET_KEY → checkout/portal/webhooks stay off and
+   * plan-limit gating is skipped so the rest of the app is unaffected. Set the secret (and price
+   * IDs) in .env to turn Cloud billing back on.
+   */
+  readonly isStripeBillingEnabled = Boolean(this.stripeSecretKey?.trim());
   // Forces the detected country (e.g. "IN") for every request. Local stacks and staging see only
   // private IPs, which can't be geolocated, so without this the India price list is untestable.
   // Must stay unset in production — it would hand INR pricing to every visitor.

--- a/Tesbo-Backend-Nest/src/plan-limits/plan-limits.service.ts
+++ b/Tesbo-Backend-Nest/src/plan-limits/plan-limits.service.ts
@@ -202,6 +202,7 @@ export class PlanLimitsService {
   }
 
   async assertCanCreateProject(organizationId: string): Promise<void> {
+    if (!this.config.isStripeBillingEnabled) return;
     const { effectivePlan, plan } = await this.getEntitlement(organizationId);
     const limit = PROJECT_LIMITS[effectivePlan];
     if (limit == null) return;
@@ -226,6 +227,7 @@ export class PlanLimitsService {
    * copy anything out, and resubscribing lifts the lock immediately.
    */
   async assertProjectWritable(organizationId: string, projectId: string): Promise<void> {
+    if (!this.config.isStripeBillingEnabled) return;
     const { effectivePlan } = await this.getEntitlement(organizationId);
     const limit = PROJECT_LIMITS[effectivePlan];
     if (limit == null) return;
@@ -263,6 +265,10 @@ export class PlanLimitsService {
     organizationId: string,
     incomingBytes: number
   ): Promise<{ allowed: boolean; reason: string | null; usedBytes: number; limitBytes: number }> {
+    if (!this.config.isStripeBillingEnabled) {
+      const used = await this.getStorageUsedBytes(organizationId);
+      return { allowed: true, reason: null, usedBytes: used, limitBytes: Number.MAX_SAFE_INTEGER };
+    }
     const { effectivePlan, plan } = await this.getEntitlement(organizationId);
     const limit = STORAGE_LIMITS_BYTES[effectivePlan];
     const used = await this.getStorageUsedBytes(organizationId);
@@ -348,6 +354,7 @@ export class PlanLimitsService {
   }
 
   async assertCustomFieldsEnabled(organizationId: string): Promise<void> {
+    if (!this.config.isStripeBillingEnabled) return;
     const { effectivePlan } = await this.getEntitlement(organizationId);
     if (effectivePlan !== "pro") {
       throw new ForbiddenException({
@@ -357,6 +364,7 @@ export class PlanLimitsService {
   }
 
   async assertIntegrationAllowed(organizationId: string, provider: string): Promise<void> {
+    if (!this.config.isStripeBillingEnabled) return;
     const { effectivePlan } = await this.getEntitlement(organizationId);
     if (effectivePlan === "pro" || LAUNCH_ALLOWED_INTEGRATIONS.has(provider)) return;
     throw new ForbiddenException({
@@ -365,11 +373,24 @@ export class PlanLimitsService {
   }
 
   async getUsageSummary(organizationId: string): Promise<PlanUsageSummary> {
-    const { plan, effectivePlan, inGracePeriod, graceEndsAt } = await this.getEntitlement(organizationId);
     const [projectCount, storageUsedBytes] = await Promise.all([
       this.getProjectCount(organizationId),
       this.getStorageUsedBytes(organizationId)
     ]);
+    // Without Stripe configured there is no paid upgrade path — do not enforce Launch ceilings.
+    if (!this.config.isStripeBillingEnabled) {
+      return {
+        plan: "pro",
+        projectCount,
+        projectLimit: null,
+        storageUsedBytes,
+        storageLimitBytes: Number.MAX_SAFE_INTEGER,
+        inGracePeriod: false,
+        graceEndsAt: null,
+        supportContactEmail: this.config.supportContactEmail
+      };
+    }
+    const { plan, effectivePlan, inGracePeriod, graceEndsAt } = await this.getEntitlement(organizationId);
     return {
       plan,
       projectCount,

--- a/Tesbo-Frontend/app/(app)/projects/[id]/settings/custom-fields/page.tsx
+++ b/Tesbo-Frontend/app/(app)/projects/[id]/settings/custom-fields/page.tsx
@@ -71,7 +71,7 @@ export default function CustomFieldsSettingsPage() {
     ? normalizeRole(projectMembers.find((m) => m.userId === currentUserId)?.role ?? "qa_engineer")
     : "qa_engineer";
   const canManage = currentUserRole === "owner" || currentUserRole === "manager";
-  const isPro = billingInfo?.plan === "pro";
+  const isPro = billingInfo?.enabled === false || billingInfo?.plan === "pro";
 
   const header = (
     <PageHeader

--- a/Tesbo-Frontend/app/(app)/projects/[id]/settings/page.tsx
+++ b/Tesbo-Frontend/app/(app)/projects/[id]/settings/page.tsx
@@ -246,7 +246,7 @@ export default function ProjectSettingsPage() {
       getJiraStatus(projectId).then(setJiraStatus).catch(() => {});
       getLinearStatus(projectId).then(setLinearStatus).catch(() => {});
       getBillingInfo()
-        .then((billing) => setLinearIsPro(billing.plan === "pro"))
+        .then((billing) => setLinearIsPro(billing.enabled === false || billing.plan === "pro"))
         .catch(() => setLinearIsPro(null));
       listApiKeys(projectId).then((l) => setApiTokenCount(l.length)).catch(() => {});
       listCustomFieldDefinitions(projectId).then((l) => setCustomFieldCount(l.length)).catch(() => {});

--- a/Tesbo-Frontend/app/(app)/settings/page.tsx
+++ b/Tesbo-Frontend/app/(app)/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
-import { authMe, getWorkspace } from "@/lib/api";
+import { authMe, getBillingInfo, getWorkspace } from "@/lib/api";
 import { useTopBarSlots } from "@/components/TopBarSlots";
 import { PageLoader } from "@/components/ui";
 import GeneralTab from "@/components/settings/GeneralTab";
@@ -22,6 +22,7 @@ function WorkspaceSettingsContent() {
   const [workspaceName, setWorkspaceName] = useState("");
   const [canManageWorkspace, setCanManageWorkspace] = useState(false);
   const [isPlatformAdmin, setIsPlatformAdmin] = useState(false);
+  const [billingEnabled, setBillingEnabled] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTab | null>(null);
   const { startEl: topBarStartEl, setFilled: setTopBarFilled } = useTopBarSlots();
 
@@ -33,12 +34,12 @@ function WorkspaceSettingsContent() {
             { key: "members", label: "Members" },
             { key: "integrations", label: "Integrations" },
             { key: "ai", label: "AI Providers" },
-            { key: "billing", label: "Billing" },
+            ...(billingEnabled ? ([{ key: "billing", label: "Billing" }] as const) : []),
           ] as const)
         : []),
       ...(isPlatformAdmin ? ([{ key: "admins", label: "Manage Admins" }] as const) : []),
     ],
-    [canManageWorkspace, isPlatformAdmin]
+    [canManageWorkspace, isPlatformAdmin, billingEnabled]
   );
 
   const load = useCallback(async () => {
@@ -59,6 +60,13 @@ function WorkspaceSettingsContent() {
       setWorkspaceName(workspace.name || "");
       setCanManageWorkspace(canManage);
       setIsPlatformAdmin(platformAdmin);
+      try {
+        const billing = await getBillingInfo();
+        // enabled:false → hide tab; enabled:true (or omitted on old servers) → show.
+        setBillingEnabled(billing.enabled !== false);
+      } catch {
+        setBillingEnabled(false);
+      }
       setStatus("ready");
     } catch {
       router.replace("/projects");

--- a/Tesbo-Frontend/components/settings/IntegrationsTab.tsx
+++ b/Tesbo-Frontend/components/settings/IntegrationsTab.tsx
@@ -56,7 +56,7 @@ export default function IntegrationsTab() {
   const [pricingOpen, setPricingOpen] = useState(false);
 
   const canManage = workspaceRole === "owner";
-  const isPro = billingInfo?.plan === "pro";
+  const isPro = billingInfo?.enabled === false || billingInfo?.plan === "pro";
 
   const loadData = useCallback(async () => {
     try {

--- a/Tesbo-Frontend/lib/api.ts
+++ b/Tesbo-Frontend/lib/api.ts
@@ -268,6 +268,8 @@ export async function updateWorkspace(data: { name: string; country?: string }):
 export type BillingInterval = "monthly" | "annual";
 
 export interface BillingInfo {
+  /** False when server has no STRIPE_SECRET_KEY — billing UI should hide. */
+  enabled: boolean;
   plan: "launch" | "pro";
   billingInterval: BillingInterval | null;
   status: string | null;

--- a/docker.env.example
+++ b/docker.env.example
@@ -83,7 +83,10 @@ NEXT_PUBLIC_BETTERBUGS_API_KEY=
 NEXT_PUBLIC_BETTERBUGS_PROJECT_ID=
 
 # -----------------------------------------------------------------------------
-# Stripe billing (Tesbo Cloud plans)
+# Stripe billing (Tesbo Cloud plans) — OPTIONAL
+# Leave STRIPE_SECRET_KEY empty → billing UI/API stay off and plan limits are not enforced
+# (projects/storage/custom fields/integrations work unrestricted).
+# Set STRIPE_SECRET_KEY (+ price IDs / webhook secret) → Stripe billing works as before.
 # STRIPE_WEBHOOK_SECRET from `stripe listen` (local) or Dashboard webhook (prod).
 # INR price IDs: set BOTH or neither (India pricing).
 # BILLING_FORCE_COUNTRY: empty in production; use IN only for local/staging tests.


### PR DESCRIPTION
Empty key disables billing and skips plan-limit enforcement so self-hosted installs stay unrestricted.

## Summary

Describe what changed and why.

## Validation

- [ ] Frontend checks pass, if changed
- [ ] Backend checks pass, if changed
- [ ] Documentation updated, if needed

## Notes

Mention migration steps, config changes, screenshots, or follow-up work.
